### PR TITLE
client,store: use the same data structure for arg/result

### DIFF
--- a/client/balancer.go
+++ b/client/balancer.go
@@ -35,17 +35,17 @@ const (
 // Balancer is a wrapper interface to batch get balances
 type Balancer interface {
 	// BalanceOf returns the balances of ETH and multiple erc20 tokens for multiple accounts
-	BalanceOf(context.Context, *big.Int, map[ethCommon.Address]map[ethCommon.Address]struct{}) (map[ethCommon.Address]map[ethCommon.Address]*big.Int, error)
+	BalanceOf(context.Context, *big.Int, *map[ethCommon.Address]map[ethCommon.Address]*big.Int) error
 }
 
 // BalanceOf returns the balances of ETH and multiple erc20 tokens for multiple accounts
-func (c *client) BalanceOf(ctx context.Context, blockNumber *big.Int, addrs map[ethCommon.Address]map[ethCommon.Address]struct{}) (balances map[ethCommon.Address]map[ethCommon.Address]*big.Int, err error) {
+func (c *client) BalanceOf(ctx context.Context, blockNumber *big.Int, balances *map[ethCommon.Address]map[ethCommon.Address]*big.Int) (err error) {
 	logger := log.New("number", blockNumber.Int64())
 
 	var msgs []*ethereum.CallMsg
 	var owners []ethCommon.Address
 	// Only handle non-ETH balances
-	for erc20Addr, list := range addrs {
+	for erc20Addr, list := range *balances {
 		if erc20Addr == model.ETHAddress {
 			continue
 		}
@@ -55,8 +55,6 @@ func (c *client) BalanceOf(ctx context.Context, blockNumber *big.Int, addrs map[
 			owners = append(owners, addr)
 		}
 	}
-
-	balances = make(map[ethCommon.Address]map[ethCommon.Address]*big.Int)
 
 	// Get batch results
 	lens := len(msgs)
@@ -70,44 +68,29 @@ func (c *client) BalanceOf(ctx context.Context, blockNumber *big.Int, addrs map[
 		logger.Info("processing ERC20 balance chunk", "total", lens, "begin", begin, "end", end)
 		outputs, err := c.BatchCallContract(ctx, chunk, blockNumber)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		for i := 0; i < len(chunk); i++ {
 			balance, err := contracts.DecodeBalanceOf(outputs[i])
 			if err != nil {
-				return nil, err
+				return err
 			}
 
 			contractAddr := *chunk[i].To
-			if balances[contractAddr] == nil {
-				balances[contractAddr] = make(map[ethCommon.Address]*big.Int)
-			}
-			balances[contractAddr][owners[begin+i]] = balance
+			(*balances)[contractAddr][owners[begin+i]] = balance
 		}
 	}
 
 	// Handle ETH balances
-	if _, ok := addrs[model.ETHAddress]; ok {
-		balances[model.ETHAddress], err = c.ethBalanceOf(ctx, blockNumber, addrs[model.ETHAddress])
-		if err != nil {
-			return nil, err
-		}
+	if _, ok := (*balances)[model.ETHAddress]; !ok {
+		return
 	}
-	return
-}
 
-// ethBalanceOf returns the ether balances
-func (c *client) ethBalanceOf(ctx context.Context, blockNumber *big.Int, addrs map[ethCommon.Address]struct{}) (etherBalances map[ethCommon.Address]*big.Int, err error) {
-	logger := log.New("number", blockNumber.Int64())
-	lens := len(addrs)
 	var addrList []ethCommon.Address
-	for addr := range addrs {
+	for addr := range (*balances)[model.ETHAddress] {
 		addrList = append(addrList, addr)
 	}
-
-	// Construct ether balances
-	etherBalances = make(map[ethCommon.Address]*big.Int, lens)
 
 	// Get ethers
 	for begin := 0; begin < lens; begin += chunkSize {
@@ -120,11 +103,11 @@ func (c *client) ethBalanceOf(ctx context.Context, blockNumber *big.Int, addrs m
 		logger.Info("processing ETH balance chunk", "total", lens, "begin", begin, "end", end)
 		ethers, err := c.BatchBalanceAt(ctx, chunk, blockNumber)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		for i, e := range ethers {
-			etherBalances[addrList[begin+i]] = e
+			(*balances)[model.ETHAddress][addrList[begin+i]] = e
 		}
 	}
 	return

--- a/client/mocks/Balancer.go
+++ b/client/mocks/Balancer.go
@@ -13,24 +13,15 @@ type Balancer struct {
 }
 
 // BalanceOf provides a mock function with given fields: _a0, _a1, _a2
-func (_m *Balancer) BalanceOf(_a0 context.Context, _a1 *big.Int, _a2 map[common.Address]map[common.Address]struct{}) (map[common.Address]map[common.Address]*big.Int, error) {
+func (_m *Balancer) BalanceOf(_a0 context.Context, _a1 *big.Int, _a2 *map[common.Address]map[common.Address]*big.Int) error {
 	ret := _m.Called(_a0, _a1, _a2)
 
-	var r0 map[common.Address]map[common.Address]*big.Int
-	if rf, ok := ret.Get(0).(func(context.Context, *big.Int, map[common.Address]map[common.Address]struct{}) map[common.Address]map[common.Address]*big.Int); ok {
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *big.Int, *map[common.Address]map[common.Address]*big.Int) error); ok {
 		r0 = rf(_a0, _a1, _a2)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[common.Address]map[common.Address]*big.Int)
-		}
+		r0 = ret.Error(0)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *big.Int, map[common.Address]map[common.Address]struct{}) error); ok {
-		r1 = rf(_a0, _a1, _a2)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }

--- a/client/mocks/EthClient.go
+++ b/client/mocks/EthClient.go
@@ -39,26 +39,17 @@ func (_m *EthClient) BalanceAt(ctx context.Context, account common.Address, bloc
 }
 
 // BalanceOf provides a mock function with given fields: _a0, _a1, _a2
-func (_m *EthClient) BalanceOf(_a0 context.Context, _a1 *big.Int, _a2 map[common.Address]map[common.Address]struct{}) (map[common.Address]map[common.Address]*big.Int, error) {
+func (_m *EthClient) BalanceOf(_a0 context.Context, _a1 *big.Int, _a2 *map[common.Address]map[common.Address]*big.Int) error {
 	ret := _m.Called(_a0, _a1, _a2)
 
-	var r0 map[common.Address]map[common.Address]*big.Int
-	if rf, ok := ret.Get(0).(func(context.Context, *big.Int, map[common.Address]map[common.Address]struct{}) map[common.Address]map[common.Address]*big.Int); ok {
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *big.Int, *map[common.Address]map[common.Address]*big.Int) error); ok {
 		r0 = rf(_a0, _a1, _a2)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[common.Address]map[common.Address]*big.Int)
-		}
+		r0 = ret.Error(0)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *big.Int, map[common.Address]map[common.Address]struct{}) error); ok {
-		r1 = rf(_a0, _a1, _a2)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // BatchBalanceAt provides a mock function with given fields: ctx, accounts, blockNumber

--- a/store/transfer_processor.go
+++ b/store/transfer_processor.go
@@ -106,7 +106,7 @@ func (s *transferProcessor) process(ctx context.Context, events []*model.Transfe
 		return err
 	}
 
-	contractsAddrs := make(map[gethCommon.Address]map[gethCommon.Address]struct{})
+	balancesByContracts := make(map[gethCommon.Address]map[gethCommon.Address]*big.Int)
 	newSubs := make(map[gethCommon.Address]*model.Subscription)
 	var newAddrs [][]byte
 	for _, sub := range newSubResults {
@@ -115,10 +115,10 @@ func (s *transferProcessor) process(ctx context.Context, events []*model.Transfe
 		newSubs[newAddr] = sub
 		// Make sure to collect ETH/ERC20 balances for the new subscriptions too.
 		for token := range s.tokenList {
-			if contractsAddrs[token] == nil {
-				contractsAddrs[token] = make(map[gethCommon.Address]struct{})
+			if balancesByContracts[token] == nil {
+				balancesByContracts[token] = make(map[gethCommon.Address]*big.Int)
 			}
-			contractsAddrs[token][newAddr] = struct{}{}
+			balancesByContracts[token][newAddr] = new(big.Int)
 		}
 	}
 
@@ -158,16 +158,16 @@ func (s *transferProcessor) process(ctx context.Context, events []*model.Transfe
 			return err
 		}
 		contractAddr := gethCommon.BytesToAddress(e.Address)
-		if contractsAddrs[contractAddr] == nil {
-			contractsAddrs[contractAddr] = make(map[gethCommon.Address]struct{})
+		if balancesByContracts[contractAddr] == nil {
+			balancesByContracts[contractAddr] = make(map[gethCommon.Address]*big.Int)
 		}
 		if hasFrom {
 			from := gethCommon.BytesToAddress(e.From)
-			contractsAddrs[contractAddr][from] = struct{}{}
+			balancesByContracts[contractAddr][from] = new(big.Int)
 		}
 		if hasTo {
 			to := gethCommon.BytesToAddress(e.To)
-			contractsAddrs[contractAddr][to] = struct{}{}
+			balancesByContracts[contractAddr][to] = new(big.Int)
 		}
 
 		if e.IsMinerRewardEvent() {
@@ -212,23 +212,23 @@ func (s *transferProcessor) process(ctx context.Context, events []*model.Transfe
 		} else {
 			feeDiff[from] = new(big.Int).Add(feeDiff[from], fee)
 		}
-		if contractsAddrs[model.ETHAddress] == nil {
-			contractsAddrs[model.ETHAddress] = make(map[gethCommon.Address]struct{})
+		if balancesByContracts[model.ETHAddress] == nil {
+			balancesByContracts[model.ETHAddress] = make(map[gethCommon.Address]*big.Int)
 		}
-		contractsAddrs[model.ETHAddress][from] = struct{}{}
+		balancesByContracts[model.ETHAddress][from] = new(big.Int)
 	}
 
 	// Get balances
-	results, err := s.balancer.BalanceOf(ctx, big.NewInt(s.blockNumber), contractsAddrs)
+	err = s.balancer.BalanceOf(ctx, big.NewInt(s.blockNumber), &balancesByContracts)
 	if err != nil {
-		s.logger.Error("Failed to get ERC20 balance with ethclient", "len", len(contractsAddrs), "err", err)
+		s.logger.Error("Failed to get ERC20 balance with ethclient", "len", len(balancesByContracts), "err", err)
 		return err
 	}
 
 	// Insert balance and calculate diff to total balances
 	addrDiff := make(map[gethCommon.Address]map[gethCommon.Address]*big.Int)
 	allAddrs := append(addrs, newAddrs...)
-	for contractAddr, addrs := range results {
+	for contractAddr, addrs := range balancesByContracts {
 		// Get last recorded balance for these accounts
 		latestBalances, err := s.getLatestBalances(contractAddr, allAddrs)
 		if err != nil {

--- a/store/transfer_processor_test.go
+++ b/store/transfer_processor_test.go
@@ -29,6 +29,7 @@ import (
 	subsStore "github.com/getamis/eth-indexer/store/subscription"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
 )
 
 var _ = Describe("Subscription Test", func() {
@@ -308,67 +309,33 @@ var _ = Describe("Subscription Test", func() {
 		Expect(err).Should(BeNil())
 
 		// For the 100 block
-		mockBalancer.On("BalanceOf", ctx, big.NewInt(100), map[gethCommon.Address]map[gethCommon.Address]struct{}{
-			model.ETHAddress: {
-				gethCommon.BytesToAddress(subs[0].Address): struct{}{},
-				gethCommon.BytesToAddress(subs[1].Address): struct{}{},
-				gethCommon.BytesToAddress(subs[2].Address): struct{}{},
-			},
-			gethCommon.BytesToAddress(erc20.Address): {
-				gethCommon.BytesToAddress(subs[0].Address): struct{}{},
-				gethCommon.BytesToAddress(subs[1].Address): struct{}{},
-				gethCommon.BytesToAddress(subs[2].Address): struct{}{},
-			},
-		}).Return(map[gethCommon.Address]map[gethCommon.Address]*big.Int{
-			model.ETHAddress: {
-				gethCommon.BytesToAddress(subs[0].Address): big.NewInt(999),
-				gethCommon.BytesToAddress(subs[1].Address): big.NewInt(100),
-				gethCommon.BytesToAddress(subs[2].Address): big.NewInt(500),
-			},
-			gethCommon.BytesToAddress(erc20.Address): {
-				gethCommon.BytesToAddress(subs[0].Address): big.NewInt(2000),
-				gethCommon.BytesToAddress(subs[1].Address): big.NewInt(150),
-				gethCommon.BytesToAddress(subs[2].Address): big.NewInt(1000),
-			},
-		}, nil).Once()
+		mockBalancer.On("BalanceOf", ctx, big.NewInt(100), mock.Anything).Run(func(args mock.Arguments) {
+			result := *args.Get(2).(*map[gethCommon.Address]map[gethCommon.Address]*big.Int)
+			result[model.ETHAddress][gethCommon.BytesToAddress(subs[0].Address)] = big.NewInt(999)
+			result[model.ETHAddress][gethCommon.BytesToAddress(subs[1].Address)] = big.NewInt(100)
+			result[model.ETHAddress][gethCommon.BytesToAddress(subs[2].Address)] = big.NewInt(500)
+			result[gethCommon.BytesToAddress(erc20.Address)][gethCommon.BytesToAddress(subs[0].Address)] = big.NewInt(2000)
+			result[gethCommon.BytesToAddress(erc20.Address)][gethCommon.BytesToAddress(subs[1].Address)] = big.NewInt(150)
+			result[gethCommon.BytesToAddress(erc20.Address)][gethCommon.BytesToAddress(subs[2].Address)] = big.NewInt(1000)
+		}).Return(nil).Once()
 
 		// For the 101 block
-		mockBalancer.On("BalanceOf", ctx, big.NewInt(101), map[gethCommon.Address]map[gethCommon.Address]struct{}{
-			model.ETHAddress: {
-				gethCommon.BytesToAddress(subs[0].Address): struct{}{},
-				gethCommon.BytesToAddress(subs[1].Address): struct{}{},
-				gethCommon.BytesToAddress(subs[2].Address): struct{}{},
-			},
-			gethCommon.BytesToAddress(erc20.Address): {
-				gethCommon.BytesToAddress(subs[0].Address): struct{}{},
-				gethCommon.BytesToAddress(subs[1].Address): struct{}{},
-				gethCommon.BytesToAddress(subs[2].Address): struct{}{},
-			},
-		}).Return(map[gethCommon.Address]map[gethCommon.Address]*big.Int{
-			model.ETHAddress: {
-				gethCommon.BytesToAddress(subs[0].Address): big.NewInt(1000),
-				gethCommon.BytesToAddress(subs[1].Address): big.NewInt(101),
-				gethCommon.BytesToAddress(subs[2].Address): big.NewInt(458),
-			},
-			gethCommon.BytesToAddress(erc20.Address): {
-				gethCommon.BytesToAddress(subs[0].Address): big.NewInt(2000),
-				gethCommon.BytesToAddress(subs[1].Address): big.NewInt(151),
-				gethCommon.BytesToAddress(subs[2].Address): big.NewInt(999),
-			},
-		}, nil).Once()
+		mockBalancer.On("BalanceOf", ctx, big.NewInt(101), mock.Anything).Run(func(args mock.Arguments) {
+			result := *args.Get(2).(*map[gethCommon.Address]map[gethCommon.Address]*big.Int)
+			result[model.ETHAddress][gethCommon.BytesToAddress(subs[0].Address)] = big.NewInt(1000)
+			result[model.ETHAddress][gethCommon.BytesToAddress(subs[1].Address)] = big.NewInt(101)
+			result[model.ETHAddress][gethCommon.BytesToAddress(subs[2].Address)] = big.NewInt(458)
+			result[gethCommon.BytesToAddress(erc20.Address)][gethCommon.BytesToAddress(subs[0].Address)] = big.NewInt(2000)
+			result[gethCommon.BytesToAddress(erc20.Address)][gethCommon.BytesToAddress(subs[1].Address)] = big.NewInt(151)
+			result[gethCommon.BytesToAddress(erc20.Address)][gethCommon.BytesToAddress(subs[2].Address)] = big.NewInt(999)
+		}).Return(nil).Once()
 
 		// For the 102 block
-		mockBalancer.On("BalanceOf", ctx, big.NewInt(102), map[gethCommon.Address]map[gethCommon.Address]struct{}{
-			model.ETHAddress: {
-				gethCommon.BytesToAddress(subs[1].Address): struct{}{},
-				gethCommon.BytesToAddress(subs[2].Address): struct{}{},
-			},
-		}).Return(map[gethCommon.Address]map[gethCommon.Address]*big.Int{
-			model.ETHAddress: {
-				gethCommon.BytesToAddress(subs[1].Address): big.NewInt(201),
-				gethCommon.BytesToAddress(subs[2].Address): big.NewInt(438),
-			},
-		}, nil).Once()
+		mockBalancer.On("BalanceOf", ctx, big.NewInt(102), mock.Anything).Run(func(args mock.Arguments) {
+			result := *args.Get(2).(*map[gethCommon.Address]map[gethCommon.Address]*big.Int)
+			result[model.ETHAddress][gethCommon.BytesToAddress(subs[1].Address)] = big.NewInt(201)
+			result[model.ETHAddress][gethCommon.BytesToAddress(subs[2].Address)] = big.NewInt(438)
+		}).Return(nil).Once()
 
 		err = manager.UpdateBlocks(ctx, blocks, receipts, events, ModeReOrg)
 		Expect(err).Should(BeNil())
@@ -533,35 +500,19 @@ var _ = Describe("Subscription Test", func() {
 			{},
 		}
 
-		mockBalancer.On("BalanceOf", ctx, big.NewInt(100), map[gethCommon.Address]map[gethCommon.Address]struct{}{
-			model.ETHAddress: {
-				gethCommon.BytesToAddress(subs[1].Address): struct{}{},
-				gethCommon.BytesToAddress(subs[2].Address): struct{}{},
-			},
-			gethCommon.BytesToAddress(erc20.Address): {
-				gethCommon.BytesToAddress(subs[1].Address): struct{}{},
-				gethCommon.BytesToAddress(subs[2].Address): struct{}{},
-			},
-		}).Return(map[gethCommon.Address]map[gethCommon.Address]*big.Int{
-			model.ETHAddress: {
-				gethCommon.BytesToAddress(subs[1].Address): big.NewInt(112),
-				gethCommon.BytesToAddress(subs[2].Address): big.NewInt(113),
-			},
-			gethCommon.BytesToAddress(erc20.Address): {
-				gethCommon.BytesToAddress(subs[1].Address): big.NewInt(212),
-				gethCommon.BytesToAddress(subs[2].Address): big.NewInt(213),
-			},
-		}, nil).Once()
+		mockBalancer.On("BalanceOf", ctx, big.NewInt(100), mock.Anything).Run(func(args mock.Arguments) {
+			result := *args.Get(2).(*map[gethCommon.Address]map[gethCommon.Address]*big.Int)
+			result[model.ETHAddress][gethCommon.BytesToAddress(subs[1].Address)] = big.NewInt(112)
+			result[model.ETHAddress][gethCommon.BytesToAddress(subs[2].Address)] = big.NewInt(113)
+			result[gethCommon.BytesToAddress(erc20.Address)][gethCommon.BytesToAddress(subs[1].Address)] = big.NewInt(212)
+			result[gethCommon.BytesToAddress(erc20.Address)][gethCommon.BytesToAddress(subs[2].Address)] = big.NewInt(213)
+		}).Return(nil).Once()
 
-		mockBalancer.On("BalanceOf", ctx, big.NewInt(102), map[gethCommon.Address]map[gethCommon.Address]struct{}{
-			model.ETHAddress: {
-				gethCommon.BytesToAddress(subs[0].Address): struct{}{},
-			},
-		}).Return(map[gethCommon.Address]map[gethCommon.Address]*big.Int{
-			model.ETHAddress: {
-				gethCommon.BytesToAddress(subs[0].Address): big.NewInt(1000),
-			},
-		}, nil).Once()
+		mockBalancer.On("BalanceOf", ctx, big.NewInt(102), mock.Anything).Run(func(args mock.Arguments) {
+			result := *args.Get(2).(*map[gethCommon.Address]map[gethCommon.Address]*big.Int)
+			result[model.ETHAddress][gethCommon.BytesToAddress(subs[0].Address)] = big.NewInt(1000)
+		}).Return(nil).Once()
+
 		err = manager.UpdateBlocks(ctx, blocks, receipts, events, ModeReOrg)
 		Expect(err).Should(BeNil())
 


### PR DESCRIPTION
when querying geth for erc20/eth balances, reduce memory usage by ~1/2.